### PR TITLE
[ci skip] adding user @kevingovaerts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @JFreitas9
+* @kevingovaerts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,4 +35,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - kevingovaerts
     - JFreitas9


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @kevingovaerts as instructed in #5.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #5